### PR TITLE
fix: disconnect request after completion

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,4 +1,7 @@
 import pytest
+from aiohttp import ClientSession
+
+from aiohttp_asgi_connector import ASGIApplicationConnector
 
 
 async def test_bad_method(session):
@@ -30,3 +33,22 @@ async def test_app_failure_propagate(session):
     with pytest.raises(Exception, match="something bad happened"):
         async with session.get("/fail?handle=false") as resp:
             assert await resp.json()
+
+
+async def test_disconnect_after_response_sent():
+    async def app(scope, receive, send):
+        while (await receive()).get("more_body", False):
+            pass
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+        # After the response is sent we should get a 'disconnected' event, see
+        # https://asgi.readthedocs.io/en/latest/specs/www.html#disconnect-receive-event
+        assert (await receive()).get("type") == "http.disconnect"
+
+    async with ClientSession(connector=ASGIApplicationConnector(app)) as session:
+        async with session.post(
+            "http://localhost/",
+            data=b"hello world",
+        ) as resp:
+            assert resp.status == 204


### PR DESCRIPTION
After the request has been fully read by the ASGI application, we previously continued returning a `{"type": "http.request", "body": b"", "more_body": False}` when `receive()` is called. Instead, we should wait for the response to be done, and then send a `{"type": "http.disconnect"}` to simulate the HTTP client having disconnected after the request was fully completed.

This broke compatibility with the Starlette's`BaseHTTPMiddleware` because they check that after the request has been completed the only valid event type is a disconnect (see [here](https://github.com/encode/starlette/blob/c78c9aac17a4d68e0647252310044502f1b7da71/starlette/middleware/base.py#L52-L58)).