### PR TITLE
feat: support aiohttp-serialized requests and streamed responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ asyncio.run(main())
 
 Exceptions raised within the ASGI application that are not handled by middleware are propagated.
 
-Since no HTTP packets are actually sent, request chunking and compression have no effect when used.
+This connector transmits the request to the ASGI application _exactly_ as it is serialized by AIOHTTP. If upload chunking or compression are enabled for your `ClientSession` requests, your ASGI application will need to be able to handle de-chunking and de-compressing; FastAPI / Starlette do not do this by default. Support to enable connector-side dechunking and decompressing may come as a future feature if a need is demonstrated for it (file an Issue).
 
 This library does not handle ASGI lifespan events. If you want to run those events, use this library in conjunction with something like [asgi-lifespan](https://pypi.org/project/asgi-lifespan/):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from aiohttp import ClientSession
 from fastapi import Body, FastAPI, Form, HTTPException
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pytest_asyncio import is_async_test
 from typing_extensions import Annotated
 
@@ -38,6 +38,11 @@ async def fail(handle: bool):
     if handle:
         raise HTTPException(status_code=500, detail="something bad happened")
     raise Exception("something bad happened")
+
+
+@app.get("/stream")
+async def stream():
+    return StreamingResponse((c for c in "{}"), media_type="application/json")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientTimeout
 
 from aiohttp_asgi_connector import ASGIApplicationConnector
 
@@ -69,6 +69,6 @@ async def test_disconnect_after_response_sent():
             assert resp.status == 204
 
 
-# async def test_app_stream(session):
-#     async with session.get("/stream", timeout=ClientTimeout(total=3)) as resp:
-#         assert await resp.json() == {}
+async def test_app_stream(session):
+    async with session.get("/stream", timeout=ClientTimeout(total=3)) as resp:
+        assert await resp.json() == {}

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,9 +1,18 @@
-import asyncio
-
 import pytest
 from aiohttp import ClientSession, ClientTimeout
 
 from aiohttp_asgi_connector import ASGIApplicationConnector
+
+
+async def test_app_failure_handled(session):
+    async with session.get("/fail?handle=true") as resp:
+        assert await resp.json()
+
+
+async def test_app_failure_propagate(session):
+    with pytest.raises(Exception, match="something bad happened"):
+        async with session.get("/fail?handle=false") as resp:
+            assert await resp.json()
 
 
 async def test_bad_method(session):
@@ -21,39 +30,21 @@ async def test_post_json(session):
         assert (await resp.json()) == {"broadcast": "hello world"}
 
 
-@pytest.mark.xfail(reason="Missing Chunked Transfer-Encoding support")
-async def test_post_stream(session):
-    async def stream():
-        yield b'{"message": '
-        await asyncio.sleep(0)
-        yield b'"hello world"}'
-
-    async with session.post(
-        "/post_json", data=stream(), headers={"Content-Type": "application/json"}
-    ) as resp:
-        assert (await resp.json()) == {"broadcast": "hello world"}
-
-
 async def test_post_form(session):
     async with session.post("/post_form", data={"message": "hello world"}) as resp:
         assert (await resp.json()) == {"broadcast": "hello world"}
 
 
-async def test_app_failure_handled(session):
-    async with session.get("/fail?handle=true") as resp:
-        assert await resp.json()
-
-
-async def test_app_failure_propagate(session):
-    with pytest.raises(Exception, match="something bad happened"):
-        async with session.get("/fail?handle=false") as resp:
-            assert await resp.json()
+async def test_app_stream(session):
+    async with session.get("/stream", timeout=ClientTimeout(total=3)) as resp:
+        assert await resp.json() == {}
 
 
 async def test_disconnect_after_response_sent():
     async def app(scope, receive, send):
         while (await receive()).get("more_body", False):
             pass
+
         await send({"type": "http.response.start", "status": 204, "headers": []})
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
@@ -62,13 +53,5 @@ async def test_disconnect_after_response_sent():
         assert (await receive()).get("type") == "http.disconnect"
 
     async with ClientSession(connector=ASGIApplicationConnector(app)) as session:
-        async with session.post(
-            "http://localhost/",
-            data=b"hello world",
-        ) as resp:
+        async with session.post("http://localhost") as resp:
             assert resp.status == 204
-
-
-async def test_app_stream(session):
-    async with session.get("/stream", timeout=ClientTimeout(total=3)) as resp:
-        assert await resp.json() == {}


### PR DESCRIPTION
Stop serializing requests ourselves and just use the payload aiohttp created.

Support streaming responses by chunked transfer-encoding bodies without a defined content length.